### PR TITLE
Add ability to insert and select on nulls in prepared statement

### DIFF
--- a/src/gmysql.gleam
+++ b/src/gmysql.gleam
@@ -122,6 +122,9 @@ pub fn exec_with_timeout(
 @external(erlang, "gmysql_ffi", "to_param")
 pub fn to_param(param: a) -> Param
 
+@external(erlang, "gmysql_ffi", "null_param")
+pub fn null_param() -> Param
+
 @external(erlang, "gmysql_ffi", "to_pid")
 pub fn to_pid(connection: Connection) -> Pid
 

--- a/src/gmysql_ffi.erl
+++ b/src/gmysql_ffi.erl
@@ -69,7 +69,8 @@ with_transaction(Connection, Function, Retries) ->
     F = fun() ->
         case Function(Connection) of
             {ok, Result} -> {ok, Result};
-            {error, Reason} -> throw({transaction_function_errored, Reason})
+            {error, Reason} -> 
+                throw({transaction_function_errored, Reason})
         end
     end,
     case mysql:transaction(Connection, F, Retries) of

--- a/src/gmysql_ffi.erl
+++ b/src/gmysql_ffi.erl
@@ -73,12 +73,9 @@ with_transaction(Connection, Function, Retries) ->
         end
     end,
     case mysql:transaction(Connection, F, Retries) of
-        {atomic, Result} ->
-            {ok, Result};
-        {aborted, {throw, {transaction_function_errored, Reason}}} ->
-            {error, {function_error, Reason}};
-        {aborted, Reason} ->
-            {error, {other_error, Reason}}
+        {atomic, Result} -> {ok, Result};
+        {aborted, {throw, {transaction_function_errored, Reason}}} -> {error, {function_error, Reason}};
+        {aborted, Reason} -> {error, {other_error, Reason}}
     end.
 
 close(Connection) ->

--- a/src/gmysql_ffi.erl
+++ b/src/gmysql_ffi.erl
@@ -69,7 +69,7 @@ with_transaction(Connection, Function, Retries) ->
     F = fun() ->
         case Function(Connection) of
             {ok, Result} -> {ok, Result};
-            {error, Reason} -> 
+            {error, Reason} ->
                 throw({transaction_function_errored, Reason})
         end
     end,


### PR DESCRIPTION
Add a function null_param so that you can insert and select on null values in a prepared statement.

```rs
gmysql.query("INSERT INTO user(username, email) VALUES(?, ?)", gmysql.default_connection(), [gmysql.to_param("my_username"), gmysql.null_param()], dynamic.int)
```

(i accidentally thought gmysql.to_param(Nil) did this so i closed the old pr)