### PR TITLE
Update for broken dependency.

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -18,6 +18,7 @@ mysql = ">= 1.8.0 and < 2.0.0"
 gleam_erlang = ">= 0.25.0 and < 1.0.0"
 gleam_otp = ">= 0.10.0 and < 1.0.0"
 based = ">= 3.0.1 and < 4.0.0"
+gleam_yielder = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,17 +3,19 @@
 
 packages = [
   { name = "based", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "based", source = "hex", outer_checksum = "67A90B910E6FE7D7539FC4C441FF95274447F802E91309076261B44CECBF8843" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
+  { name = "gleam_otp", version = "0.16.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "FA0EB761339749B4E82D63016C6A18C4E6662DA05BAB6F1346F9AF2E679E301A" },
+  { name = "gleam_stdlib", version = "0.52.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "50703862DF26453B277688FFCDBE9DD4AC45B3BD9742C0B370DB62BC1629A07D" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "mysql", version = "1.8.0", build_tools = ["make", "rebar3", "mix"], requirements = [], otp_app = "mysql", source = "hex", outer_checksum = "D473C479C19E5CDE20237458EEAD6673C3C00E0EF84AFD30615AEBBB67FEE7B3" },
 ]
 
 [requirements]
-based = { version = ">= 3.0.1 and < 4.0.0"}
+based = { version = ">= 3.0.1 and < 4.0.0" }
 gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 mysql = { version = ">= 1.8.0 and < 2.0.0" }

--- a/src/gmysql/pool.gleam
+++ b/src/gmysql/pool.gleam
@@ -2,11 +2,11 @@ import gleam/bool
 import gleam/erlang
 import gleam/erlang/process.{type Subject}
 import gleam/function
-import gleam/iterator
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/otp/actor.{type Next, Continue, Stop}
 import gleam/otp/intensity_tracker.{type IntensityTracker}
+import gleam/yielder
 import gmysql.{type Config, type Connection}
 
 pub opaque type Pool {
@@ -39,9 +39,9 @@ pub fn connect(
   limit max_connections_per_second: Int,
 ) {
   let slots =
-    iterator.repeat(Slot(connection: None, checked_out: False))
-    |> iterator.take(count)
-    |> iterator.to_list
+    yielder.repeat(Slot(connection: None, checked_out: False))
+    |> yielder.take(count)
+    |> yielder.to_list
 
   let assert Ok(actor) =
     actor.start(
@@ -219,10 +219,10 @@ fn handle_restart_all(_message: Message, state: State) -> Next(Message, State) {
 
 fn handle_start_new(_message: Message, state: State) -> Next(Message, State) {
   actor.continue(
-    State(
-      ..state,
-      slots: [Slot(connection: None, checked_out: False), ..state.slots],
-    ),
+    State(..state, slots: [
+      Slot(connection: None, checked_out: False),
+      ..state.slots
+    ]),
   )
 }
 


### PR DESCRIPTION
- Using gleam_yielder instead of the deprecated and removed gleam/iterator.
- Slight formatting change (Gleam v1.7.0 format)